### PR TITLE
Add in argument inspection to clean up handler calls

### DIFF
--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -65,3 +65,21 @@ class FilterTest(unittest.TestCase):
                         handler=self.handler, regex=True)
         filter(self.message("<#C1234> wants you"))
         self.assertDictContainsSubset({"who": "<#C1234>"}, self.response)
+
+    def test_dynamic_arguments(self):
+        ''' Confirm that the handler's argument signature is honored
+        Filter handlers can dictate which arguments get passed in based on its
+        function signature.  Extraneous arguments are dropped when it is called
+        rather than erroring.
+        '''
+
+        def test_handler(text, channel):
+            return (text, channel)
+
+        message = {"type": events.MESSAGE,
+                   "channel": "#test", "text": "dynamic"}
+
+        filter = Filter(self.bot, match_txt="*", handler=test_handler)
+        self.assertEqual(
+            filter(Message(self.bot, message)),
+            ("dynamic", "#test"))


### PR DESCRIPTION
This addresses #7 but currently only scoped to the listen filters.  It uses the `inspect` module to get the argspec of the handler and attempt to filter out the keys from the event dictionary that the handler isn't asking for.

I probably want to expand this logic to be more portable and move it into the `utils` file where it can be applied to other events.
