### PR TITLE
First pass at adding some reconnection logic

### DIFF
--- a/bin/start
+++ b/bin/start
@@ -3,6 +3,7 @@ from lazbot import utils
 from lazbot import logger
 import os
 import sys
+import traceback
 
 app = utils.build_namespace("app")
 
@@ -23,7 +24,13 @@ if __name__ == "__main__":
     plugins = app.config.get("plugins", [])
     utils.load_plugins(os.path.join(directory, "src", "plugins"), *plugins)
     try:
-        app.bot.start()
+        while app.bot.reconnect():
+            try:
+                app.bot.start()
+            except KeyboardInterrupt as err:
+                raise err
+            except:
+                logger.error(traceback.format_exc())
     except KeyboardInterrupt:
         sys.exit(0)
 

--- a/src/lazbot/lazbot.py
+++ b/src/lazbot/lazbot.py
@@ -128,6 +128,9 @@ class Lazbot(object):
 
         Closes the socket and turns listeners off
         """
+        if not self.running:
+            return
+
         logger.info("Stopping bot")
         self.running = False
         self.socket.close()


### PR DESCRIPTION
This creates a `Retry` class that encapsulates various options for retry logic, including randomized offsets, growth, and waits between attempts.  There needs to be some testing put into place and some effort to decouple from the Bot use should be made.  It could be used for other network actions with plugins.

This is a first pass at addressing #6 but I am going to let it bake on my instance to make sure there aren't any sleeping bugs and hopefully get an idea of how to test it easily.
